### PR TITLE
Refactor plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/cprobe/cprobe/plugins"
 	"os"
 	"os/signal"
 	"strings"
@@ -71,10 +72,13 @@ func main() {
 	buildinfo.Init()
 	logger.Init()
 	runner.PrintRuntime()
+	plugins.InitPlugin()
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	writer.Init(flags.ConfigDirectory)
+	if err := writer.Init(flags.ConfigDirectory); err != nil {
+		logger.Fatalf("cannot init writer: %v", err)
+	}
 
 	if err := probe.Start(ctx, flags.ConfigDirectory); err != nil {
 		logger.Fatalf("cannot start probe: %v", err)

--- a/plugins/interface.go
+++ b/plugins/interface.go
@@ -1,0 +1,30 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"github.com/cprobe/cprobe/plugins/mysql"
+	"github.com/cprobe/cprobe/types"
+	"github.com/pkg/errors"
+)
+
+type Plugin interface {
+	// ParseConfig is used to parse config
+	ParseConfig(bs []byte) (any, error)
+	// Scrape is used to scrape metrics, cfg need to be cost specific cfg
+	Scrape(ctx context.Context, target string, cfg any, ss *types.Samples) error
+}
+
+var plugin = make(map[string]Plugin)
+
+func InitPlugin() {
+	plugin[types.PluginMySQL] = &mysql.Mysql{Name: types.PluginMySQL}
+	plugin[types.PluginRedis] = &mysql.Mysql{Name: types.PluginRedis}
+}
+func GetPlugin(pluginName string) (Plugin, error) {
+	p, ok := plugin[pluginName]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Unknown plugin: %s", pluginName))
+	}
+	return p, nil
+}

--- a/plugins/mysql/mysql.go
+++ b/plugins/mysql/mysql.go
@@ -381,7 +381,11 @@ func (c *Config) EnabledScrapers() (ret []collector.Scraper) {
 	return
 }
 
-func ParseConfig(bs []byte) (*Config, error) {
+type Mysql struct {
+	Name string
+}
+
+func (m *Mysql) ParseConfig(bs []byte) (any, error) {
 	var c Config
 	err := toml.Unmarshal(bs, &c)
 	if err != nil {
@@ -395,7 +399,8 @@ func ParseConfig(bs []byte) (*Config, error) {
 // cprobe 是并发抓取很多个数据库实例的监控数据，不同的数据库实例其抓取参数可能不同
 // 如果直接修改 collector pkg 下面的变量，就会有并发使用变量的问题
 // 把这些自定义参数封装到一个一个的 collector.Scraper 对象中，每个 target 抓取时实例化这些 collector.Scraper 对象
-func Scrape(ctx context.Context, address string, cfg *Config, ss *types.Samples) error {
+func (m *Mysql) Scrape(ctx context.Context, address string, c any, ss *types.Samples) error {
+	cfg := c.(*Config)
 	dsn, err := cfg.Global.FormDSN(address)
 	if err != nil {
 		return fmt.Errorf("failed to form dsn for %s: %s", address, err)

--- a/plugins/redis/redis.go
+++ b/plugins/redis/redis.go
@@ -56,7 +56,11 @@ type Config struct {
 	Global Global `toml:"global"`
 }
 
-func ParseConfig(bs []byte) (*Config, error) {
+type Redis struct {
+	Name string
+}
+
+func (r *Redis) ParseConfig(bs []byte) (any, error) {
 	var c Config
 	err := toml.Unmarshal(bs, &c)
 	if err != nil {
@@ -106,7 +110,8 @@ func ParseConfig(bs []byte) (*Config, error) {
 	return &c, nil
 }
 
-func Scrape(_ context.Context, target string, cfg *Config, ss *types.Samples) error {
+func (r *Redis) Scrape(ctx context.Context, target string, c any, ss *types.Samples) error {
+	cfg := c.(*Config)
 	if !strings.Contains(target, "://") {
 		target = "redis://" + target
 	}

--- a/probe/schedule.go
+++ b/probe/schedule.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/cprobe/cprobe/plugins"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -16,8 +17,6 @@ import (
 	"github.com/cprobe/cprobe/lib/logger"
 	"github.com/cprobe/cprobe/lib/prompbmarshal"
 	"github.com/cprobe/cprobe/lib/promutils"
-	"github.com/cprobe/cprobe/plugins/mysql"
-	"github.com/cprobe/cprobe/plugins/redis"
 	"github.com/cprobe/cprobe/types"
 	"github.com/cprobe/cprobe/writer"
 	"gopkg.in/yaml.v2"
@@ -149,25 +148,14 @@ func (j *JobGoroutine) run(ctx context.Context) {
 
 	tomlBytes := bytesBuffer.Bytes()
 
-	// 不同的插件配置是不同的，需要分别解析
-	var mysqlConfig *mysql.Config
-	var redisConfig *redis.Config
-
-	switch j.plugin {
-	case types.PluginMySQL:
-		mysqlConfig, err = mysql.ParseConfig(tomlBytes)
-		if err != nil {
-			logger.Errorf("job(%s) parse mysql config error: %s", jobName, err)
-			return
-		}
-	case types.PluginRedis:
-		redisConfig, err = redis.ParseConfig(tomlBytes)
-		if err != nil {
-			logger.Errorf("job(%s) parse redis config error: %s", jobName, err)
-			return
-		}
-	default:
-		logger.Errorf("unknown plugin: %s of job: %s", j.plugin, jobName)
+	plugin, err := plugins.GetPlugin(j.plugin)
+	if err != nil {
+		logger.Errorf("job(%s) unknown plugin: %s", jobName, j.plugin)
+		return
+	}
+	config, err := plugin.ParseConfig(tomlBytes)
+	if err != nil {
+		logger.Errorf("job(%s) parse mysql config error: %s", jobName, err)
 		return
 	}
 
@@ -200,18 +188,8 @@ func (j *JobGoroutine) run(ctx context.Context) {
 			// 准备一个并发安全的容器，传给 Scrape 方法，Scrape 方法会把抓取到的数据放进去，外层还要做 relabel 然后最终发给 writer
 			ss := types.NewSamples()
 
-			// 不同的插件，调用不同的 Scrape 方法，未来这里会很长，毕竟每个插件都要写一个 switch case
-			switch j.plugin {
-			case types.PluginMySQL:
-				confCopy := *mysqlConfig
-				if serr := mysql.Scrape(ctx, targetAddress, &confCopy, ss); serr != nil {
-					logger.Errorf("job(%s) scrape mysql(%s) error: %s", jobName, targetAddress, serr)
-				}
-			case types.PluginRedis:
-				confCopy := *redisConfig
-				if serr := redis.Scrape(ctx, targetAddress, &confCopy, ss); serr != nil {
-					logger.Errorf("job(%s) scrape redis(%s) error: %s", jobName, targetAddress, serr)
-				}
+			if err = plugin.Scrape(ctx, targetAddress, config, ss); err != nil {
+				logger.Errorf("job(%s) scrape plugin(%s) error: %s", jobName, targetAddress, err)
 			}
 
 			// 把抓取到的数据做格式转换，转换成 []prompbmarshal.TimeSeries


### PR DESCRIPTION
- Leave the specific parsing and scrape bussiness to be implemented by the plugin itself.
- Remove many `switch/case` statements.