### PR TITLE
Job support external_labels

### DIFF
--- a/probe/config_struct.go
+++ b/probe/config_struct.go
@@ -56,6 +56,7 @@ type ScrapeConfig struct {
 	ConfigRef *Config `yaml:"-"`
 
 	JobName           string              `yaml:"job_name"`
+	ExternalLabels    *promutils.Labels   `yaml:"external_labels,omitempty"`
 	ScrapeConcurrency int                 `yaml:"scrape_concurrency,omitempty"`
 	ScrapeInterval    *promutils.Duration `yaml:"scrape_interval,omitempty"`
 	// ScrapeTimeout     *promutils.Duration `yaml:"scrape_timeout,omitempty"`

--- a/probe/schedule.go
+++ b/probe/schedule.go
@@ -167,6 +167,9 @@ func (j *JobGoroutine) run(ctx context.Context) {
 			}()
 
 			targetAddress := pt.Get("__address__")
+			if j.scrapeConfig.ExternalLabels != nil {
+				pt.AddFrom(j.scrapeConfig.ExternalLabels)
+			}
 
 			// 准备一个并发安全的容器，传给 Scrape 方法，Scrape 方法会把抓取到的数据放进去，外层还要做 relabel 然后最终发给 writer
 			ss := types.NewSamples()


### PR DESCRIPTION
Sometimes we need to create `scrape_interval` for every job, like this:

```yaml
global:
  scrape_interval: 15s
  external_labels:
    cplugin: 'nginx'

scrape_configs:
 - job_name: 'nginx1'
   external_labels:
     job_name: 'nginx1111'
   static_configs:
   - targets:
     - 'http://localhost:8080/nginx-status'
   scrape_rule_files:
   - 'rule.toml'
 - job_name: 'nginx2'
   external_labels:
     job_name: 'nginx222'
   static_configs:
   - targets:
     - 'http://localhost:8081/nginx-status'
   scrape_rule_files:
   - 'rule.toml'
```